### PR TITLE
Initialize TradeSense trading analytics app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+.venv/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,2 +1,42 @@
 # TradeSense
-Universal Trading Analytics & Risk Manager.
+
+**Smarter Decisions. Safer Trades.**
+
+TradeSense is a modular trading analytics and risk management app built with Streamlit. Upload your trading history, analyze performance, and manage risk with actionable insights.
+
+## Features
+
+- Upload CSV/Excel trade history from any broker.
+- Map custom column names to required fields.
+- Universal trade model works across asset classes.
+- Core analytics: win rate, expectancy, drawdown, Sharpe ratio, and more.
+- Interactive dashboards with Plotly charts.
+- Risk assessment and position sizing recommendations.
+- Sample futures data included for quick start.
+- Placeholders for Stripe/PayPal integration.
+
+## Setup
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+## Running the App
+
+```bash
+streamlit run app.py
+```
+
+Upload your trade history or try the sample file in `sample_data/`.
+
+## Extending
+
+- Add new importers in `data_import/` for forex, options, stocks, etc.
+- Integrate payment systems via `payment.py`.
+- Customize branding in `app.py` and assets.
+
+## License
+
+MIT

--- a/analytics.py
+++ b/analytics.py
@@ -1,0 +1,30 @@
+import pandas as pd
+import numpy as np
+
+
+def compute_basic_stats(df: pd.DataFrame) -> dict:
+    """Calculate core trading performance statistics."""
+    wins = df[df['pnl'] > 0]
+    losses = df[df['pnl'] <= 0]
+    win_rate = len(wins) / len(df) * 100 if len(df) else 0
+    avg_win = wins['pnl'].mean() if not wins.empty else 0
+    avg_loss = losses['pnl'].mean() if not losses.empty else 0
+    reward_risk = abs(avg_win / avg_loss) if avg_loss != 0 else np.inf
+    expectancy = (win_rate/100) * avg_win + (1 - win_rate/100) * avg_loss
+    profit_factor = wins['pnl'].sum() / abs(losses['pnl'].sum()) if not losses.empty else np.inf
+    equity_curve = df['pnl'].cumsum()
+    max_drawdown = (equity_curve.cummax() - equity_curve).max()
+    returns = equity_curve.pct_change().dropna()
+    sharpe = np.sqrt(252) * returns.mean() / returns.std() if not returns.empty else 0
+
+    return {
+        'win_rate': win_rate,
+        'average_win': avg_win,
+        'average_loss': avg_loss,
+        'reward_risk': reward_risk,
+        'expectancy': expectancy,
+        'max_drawdown': max_drawdown,
+        'profit_factor': profit_factor,
+        'sharpe_ratio': sharpe,
+        'equity_curve': equity_curve,
+    }

--- a/app.py
+++ b/app.py
@@ -1,0 +1,76 @@
+import streamlit as st
+import pandas as pd
+from pathlib import Path
+from typing import Dict
+
+from data_import.futures_importer import FuturesImporter
+from data_import.base_importer import REQUIRED_COLUMNS
+from analytics import compute_basic_stats
+from risk_tool import assess_risk
+from payment import PaymentGateway
+
+st.set_page_config(page_title="TradeSense", layout="wide")
+st.title("TradeSense")
+st.caption("Smarter Decisions. Safer Trades.")
+
+st.sidebar.header("Upload Trade History")
+
+sample_file = Path('sample_data/futures_sample.csv')
+if sample_file.exists():
+    if st.sidebar.checkbox('Use sample data'):
+        uploaded_file = open(sample_file, 'rb')
+    else:
+        uploaded_file = st.sidebar.file_uploader("Upload CSV or Excel", type=['csv','xlsx','xls'])
+else:
+    uploaded_file = st.sidebar.file_uploader("Upload CSV or Excel", type=['csv','xlsx','xls'])
+
+importer = FuturesImporter()
+
+if uploaded_file:
+    try:
+        df = importer.load(uploaded_file)
+    except Exception as e:
+        st.error(f"Error reading file: {e}")
+        st.stop()
+
+    if not importer.validate_columns(df):
+        st.warning('Columns do not match required fields. Map them below:')
+        mapping: Dict[str, str] = {}
+        for col in REQUIRED_COLUMNS:
+            mapping[col] = st.selectbox(f"Column for {col}", options=df.columns, key=col)
+        try:
+            df = importer.map_columns(df, mapping)
+        except Exception as e:
+            st.error(str(e))
+            st.stop()
+
+    # Parse datetimes
+    df['entry_time'] = pd.to_datetime(df['entry_time'])
+    df['exit_time'] = pd.to_datetime(df['exit_time'])
+
+    stats = compute_basic_stats(df)
+
+    st.subheader('Performance Metrics')
+    col1, col2, col3 = st.columns(3)
+    col1.metric('Win Rate %', f"{stats['win_rate']:.2f}")
+    col1.metric('Profit Factor', f"{stats['profit_factor']:.2f}")
+    col2.metric('Expectancy', f"{stats['expectancy']:.2f}")
+    col2.metric('Max Drawdown', f"{stats['max_drawdown']:.2f}")
+    col3.metric('Sharpe Ratio', f"{stats['sharpe_ratio']:.2f}")
+    col3.metric('Reward:Risk', f"{stats['reward_risk']:.2f}")
+
+    st.subheader('Equity Curve')
+    st.line_chart(stats['equity_curve'])
+
+    st.subheader('Risk Assessment')
+    account_size = st.number_input('Account Size', value=10000.0)
+    risk_per_trade = st.number_input('Risk % per Trade', value=0.01)
+    max_daily_loss = st.number_input('Max Daily Loss', value=500.0)
+    if st.button('Assess Risk'):
+        risk = assess_risk(df, account_size, risk_per_trade, max_daily_loss)
+        st.write(risk)
+
+    st.download_button('Download Cleaned CSV', df.to_csv(index=False), 'cleaned_trades.csv')
+else:
+    st.info('Upload a trade history file to begin or use the sample data.')
+

--- a/data_import/__init__.py
+++ b/data_import/__init__.py
@@ -1,0 +1,1 @@
+from .futures_importer import FuturesImporter

--- a/data_import/base_importer.py
+++ b/data_import/base_importer.py
@@ -1,0 +1,27 @@
+import pandas as pd
+from abc import ABC, abstractmethod
+
+REQUIRED_COLUMNS = [
+    'symbol', 'entry_time', 'exit_time', 'entry_price',
+    'exit_price', 'qty', 'direction', 'pnl', 'trade_type', 'broker'
+]
+
+class BaseImporter(ABC):
+    """Abstract base class for trade data importers."""
+
+    @abstractmethod
+    def load(self, file_path: str) -> pd.DataFrame:
+        """Load and normalize trade data from a file."""
+        pass
+
+    def validate_columns(self, df: pd.DataFrame) -> bool:
+        """Check if required columns exist."""
+        return all(col in df.columns for col in REQUIRED_COLUMNS)
+
+    def map_columns(self, df: pd.DataFrame, mapping: dict) -> pd.DataFrame:
+        """Map user-provided columns to required columns."""
+        df = df.rename(columns=mapping)
+        if not self.validate_columns(df):
+            missing = set(REQUIRED_COLUMNS) - set(df.columns)
+            raise ValueError(f"Missing required columns: {missing}")
+        return df[REQUIRED_COLUMNS]

--- a/data_import/futures_importer.py
+++ b/data_import/futures_importer.py
@@ -1,0 +1,20 @@
+import pandas as pd
+from .base_importer import BaseImporter, REQUIRED_COLUMNS
+
+class FuturesImporter(BaseImporter):
+    """Importer for futures trade history CSV/Excel files."""
+
+    def load(self, file_path: str) -> pd.DataFrame:
+        try:
+            if file_path.endswith('.xlsx') or file_path.endswith('.xls'):
+                df = pd.read_excel(file_path)
+            else:
+                df = pd.read_csv(file_path)
+        except Exception as e:
+            raise ValueError(f"Failed to read file: {e}")
+
+        if not self.validate_columns(df):
+            # return raw df for mapping step
+            return df
+
+        return df[REQUIRED_COLUMNS]

--- a/models.py
+++ b/models.py
@@ -1,0 +1,42 @@
+from dataclasses import dataclass
+from datetime import datetime
+
+@dataclass
+class Trade:
+    symbol: str
+    entry_time: datetime
+    exit_time: datetime
+    entry_price: float
+    exit_price: float
+    qty: float
+    direction: str  # 'long' or 'short'
+    pnl: float
+    trade_type: str
+    broker: str
+
+    @property
+    def duration(self) -> float:
+        """Trade duration in minutes."""
+        return (self.exit_time - self.entry_time).total_seconds() / 60
+
+    @staticmethod
+    def from_series(s: 'pd.Series') -> 'Trade':
+        from pandas import Timestamp
+        entry = s['entry_time']
+        exit_ = s['exit_time']
+        if isinstance(entry, str):
+            entry = Timestamp(entry)
+        if isinstance(exit_, str):
+            exit_ = Timestamp(exit_)
+        return Trade(
+            symbol=s['symbol'],
+            entry_time=entry.to_pydatetime(),
+            exit_time=exit_.to_pydatetime(),
+            entry_price=s['entry_price'],
+            exit_price=s['exit_price'],
+            qty=s['qty'],
+            direction=s['direction'],
+            pnl=s['pnl'],
+            trade_type=s['trade_type'],
+            broker=s['broker']
+        )

--- a/payment.py
+++ b/payment.py
@@ -1,0 +1,20 @@
+"""Payment integration placeholders for future Stripe/PayPal support."""
+
+# Placeholder imports (uncomment when dependencies are installed)
+# import stripe
+# import paypalrestsdk
+
+class PaymentGateway:
+    def __init__(self):
+        # Setup API keys or credentials here
+        pass
+
+    def check_subscription(self, user_id: str) -> bool:
+        """Stub for verifying user subscription status."""
+        # TODO: integrate with Stripe/PayPal
+        return True
+
+    def create_checkout_session(self, plan_id: str, user_id: str) -> str:
+        """Stub for creating a payment checkout session."""
+        # TODO: integrate with payment provider and return checkout URL
+        return "https://payment.example.com/checkout"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+pandas
+numpy
+plotly
+streamlit
+openpyxl
+fpdf
+# payment placeholders
+stripe
+paypalrestsdk

--- a/risk_tool.py
+++ b/risk_tool.py
@@ -1,0 +1,20 @@
+import pandas as pd
+
+
+def assess_risk(df: pd.DataFrame, account_size: float, risk_per_trade: float,
+                 max_daily_loss: float) -> dict:
+    """Simple risk assessment based on historical PnL."""
+    stats = {}
+    avg_loss = df[df['pnl'] < 0]['pnl'].mean() if not df.empty else 0
+    recommended_size = account_size * risk_per_trade / abs(avg_loss) if avg_loss else 0
+    if recommended_size > account_size:
+        recommended_size = account_size
+
+    stats['recommended_position_size'] = recommended_size
+    stats['max_daily_loss'] = max_daily_loss
+    daily_pnl = df.groupby(df['exit_time'].dt.date)['pnl'].sum()
+    if any(daily_pnl < -max_daily_loss):
+        stats['warning'] = 'Historical trades exceed your max daily loss.'
+    else:
+        stats['warning'] = ''
+    return stats

--- a/sample_data/futures_sample.csv
+++ b/sample_data/futures_sample.csv
@@ -1,0 +1,4 @@
+symbol,entry_time,exit_time,entry_price,exit_price,qty,direction,pnl,trade_type,broker
+ES,2023-01-01 09:30:00,2023-01-01 10:00:00,3900,3910,1,long,500,daytrade,DemoBroker
+ES,2023-01-02 09:30:00,2023-01-02 11:00:00,3920,3910,1,short,-500,daytrade,DemoBroker
+ES,2023-01-03 09:30:00,2023-01-03 10:15:00,3890,3905,1,long,750,daytrade,DemoBroker


### PR DESCRIPTION
## Summary
- implement initial Streamlit app for TradeSense
- add modular importers, analytics, and risk tools
- include placeholders for payment integration
- provide sample futures trade data
- document setup and usage in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6844a725cacc8330a2ae517e79c4c438