### PR TITLE
Fix sample data loading with file-like objects

### DIFF
--- a/data_import/base_importer.py
+++ b/data_import/base_importer.py
@@ -1,5 +1,6 @@
 import pandas as pd
 from abc import ABC, abstractmethod
+from typing import Union, IO, Any
 
 REQUIRED_COLUMNS = [
     'symbol', 'entry_time', 'exit_time', 'entry_price',
@@ -10,8 +11,8 @@ class BaseImporter(ABC):
     """Abstract base class for trade data importers."""
 
     @abstractmethod
-    def load(self, file_path: str) -> pd.DataFrame:
-        """Load and normalize trade data from a file."""
+    def load(self, file_obj: Union[str, IO[Any]]) -> pd.DataFrame:
+        """Load and normalize trade data from a file path or file-like object."""
         pass
 
     def validate_columns(self, df: pd.DataFrame) -> bool:

--- a/data_import/futures_importer.py
+++ b/data_import/futures_importer.py
@@ -1,12 +1,19 @@
 import pandas as pd
+from pathlib import Path
+from typing import Union, IO, Any
 from .base_importer import BaseImporter, REQUIRED_COLUMNS
 
 class FuturesImporter(BaseImporter):
     """Importer for futures trade history CSV/Excel files."""
 
-    def load(self, file_path: str) -> pd.DataFrame:
+    def load(self, file_path: Union[str, IO[Any]]) -> pd.DataFrame:
         try:
-            if file_path.endswith('.xlsx') or file_path.endswith('.xls'):
+            if isinstance(file_path, str):
+                ext = Path(file_path).suffix.lower()
+            else:
+                ext = Path(getattr(file_path, 'name', '')).suffix.lower()
+
+            if ext in ('.xlsx', '.xls'):
                 df = pd.read_excel(file_path)
             else:
                 df = pd.read_csv(file_path)


### PR DESCRIPTION
## Summary
- handle file paths and file-like objects in data importer

## Testing
- `python -m py_compile app.py analytics.py risk_tool.py payment.py data_import/*.py models.py`

------
https://chatgpt.com/codex/tasks/task_e_6844ae9e57088330a8cdcec20b496eda