### PR TITLE
Improve futures importer

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ TradeSense is a modular trading analytics and risk management app built with Str
 
 ## Features
 
-- Upload CSV/Excel trade history from any broker.
+- Upload CSV/Excel trade history from any broker. Both file paths and file-like uploads are supported.
 - Map custom column names to required fields.
 - Universal trade model works across asset classes.
 - Core analytics: win rate, expectancy, drawdown, Sharpe ratio, and more.

--- a/data_import/futures_importer.py
+++ b/data_import/futures_importer.py
@@ -6,19 +6,28 @@ from .base_importer import BaseImporter, REQUIRED_COLUMNS
 class FuturesImporter(BaseImporter):
     """Importer for futures trade history CSV/Excel files."""
 
-    def load(self, file_path: Union[str, IO[Any]]) -> pd.DataFrame:
-        try:
-            if isinstance(file_path, str):
-                ext = Path(file_path).suffix.lower()
-            else:
-                ext = Path(getattr(file_path, 'name', '')).suffix.lower()
+    def load(self, file_obj: Union[str, IO[Any]]) -> pd.DataFrame:
+        """Load futures trades from a CSV or Excel file.
 
-            if ext in ('.xlsx', '.xls'):
-                df = pd.read_excel(file_path)
+        Parameters
+        ----------
+        file_obj : str or file-like object
+            Path to the file or an object with a ``read`` method.
+        """
+        try:
+            if isinstance(file_obj, str):
+                ext = Path(file_obj).suffix.lower()
             else:
-                df = pd.read_csv(file_path)
+                ext = Path(getattr(file_obj, 'name', '')).suffix.lower()
+
+            if ext in ('.csv', '.txt'):
+                df = pd.read_csv(file_obj)
+            elif ext in ('.xlsx', '.xls'):
+                df = pd.read_excel(file_obj)
+            else:
+                raise ValueError(f"Unsupported file format: {ext}")
         except Exception as e:
-            raise ValueError(f"Failed to read file: {e}")
+            raise ValueError(f"Failed to read file: {e}") from e
 
         if not self.validate_columns(df):
             # return raw df for mapping step


### PR DESCRIPTION
## Summary
- enhance `FuturesImporter.load` to work with file-like objects and detect formats
- clarify README feature bullet about supported upload types

## Testing
- `python -m py_compile data_import/futures_importer.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844b04640b48330a3e7051fbfe49161