### PR TITLE
Add pytest tests and testing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ python -m venv .venv
 source .venv/bin/activate
 pip install -r requirements.txt
 ```
+## Testing
+
+```bash
+pytest
+```
+
 
 ## Running the App
 
@@ -41,3 +47,4 @@ sample data from `sample_data/futures_sample.csv`.
 ## License
 
 MIT
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ fpdf
 # payment placeholders
 stripe
 paypalrestsdk
+pytest
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+import sys
+from pathlib import Path
+
+# Ensure project root is on the path
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -1,0 +1,28 @@
+import pytest
+import pandas as pd
+import numpy as np
+from analytics import compute_basic_stats
+
+
+def test_compute_basic_stats_known_data():
+    data = [
+        ['ES','2023-01-01','2023-01-01',1,1,1,'long',100,'daytrade','Demo'],
+        ['ES','2023-01-02','2023-01-02',1,1,1,'long',-50,'daytrade','Demo'],
+        ['ES','2023-01-03','2023-01-03',1,1,1,'long',200,'daytrade','Demo'],
+        ['ES','2023-01-04','2023-01-04',1,1,1,'long',-100,'daytrade','Demo'],
+    ]
+    cols = ['symbol','entry_time','exit_time','entry_price','exit_price','qty','direction','pnl','trade_type','broker']
+    df = pd.DataFrame(data, columns=cols)
+
+    stats = compute_basic_stats(df)
+
+    assert stats['win_rate'] == 50.0
+    assert stats['average_win'] == 150.0
+    assert stats['average_loss'] == -75.0
+    assert stats['reward_risk'] == 2.0
+    assert stats['expectancy'] == 37.5
+    assert stats['profit_factor'] == 2.0
+    assert stats['max_drawdown'] == 100
+    # approximate due to floating point operations
+    assert stats['sharpe_ratio'] == pytest.approx(6.3835034744, rel=1e-6)
+

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -1,0 +1,13 @@
+import pandas as pd
+from data_import import FuturesImporter
+from data_import.base_importer import REQUIRED_COLUMNS
+
+
+def test_load_sample_csv():
+    importer = FuturesImporter()
+    df = importer.load('sample_data/futures_sample.csv')
+    assert isinstance(df, pd.DataFrame)
+    # should have 30 rows and required columns only
+    assert df.shape == (30, len(REQUIRED_COLUMNS))
+    assert list(df.columns) == REQUIRED_COLUMNS
+


### PR DESCRIPTION
## Summary
- add pytest to requirements
- document how to run tests in README
- cover futures importer and analytics functions with tests

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844b0fad2148330b1b225645c10017c