### PR TITLE
Fix file loading for sample and uploaded data

### DIFF
--- a/data_import/__init__.py
+++ b/data_import/__init__.py
@@ -1,1 +1,2 @@
 from .futures_importer import FuturesImporter
+from .utils import load_trade_data

--- a/data_import/futures_importer.py
+++ b/data_import/futures_importer.py
@@ -1,7 +1,7 @@
 import pandas as pd
-from pathlib import Path
 from typing import Union, IO, Any
 from .base_importer import BaseImporter, REQUIRED_COLUMNS
+from .utils import load_trade_data
 
 class FuturesImporter(BaseImporter):
     """Importer for futures trade history CSV/Excel files."""
@@ -15,22 +15,7 @@ class FuturesImporter(BaseImporter):
             Path to the file or an object with a ``read`` method.
         """
         try:
-            if isinstance(file_obj, str):
-                file_name = file_obj.lower()
-                if file_name.endswith(('.csv', '.txt')):
-                    df = pd.read_csv(file_obj)
-                elif file_name.endswith(('.xlsx', '.xls')):
-                    df = pd.read_excel(file_obj)
-                else:
-                    raise ValueError(f"Unsupported file format: {file_name}")
-            else:
-                file_name = getattr(file_obj, 'name', '').lower()
-                if file_name.endswith(('.csv', '.txt')):
-                    df = pd.read_csv(file_obj)
-                elif file_name.endswith(('.xlsx', '.xls')):
-                    df = pd.read_excel(file_obj)
-                else:
-                    raise ValueError(f"Unsupported file format: {file_name}")
+            df = load_trade_data(file_obj)
         except Exception as e:
             raise ValueError(f"Failed to read file: {e}") from e
 

--- a/data_import/utils.py
+++ b/data_import/utils.py
@@ -1,0 +1,28 @@
+import pandas as pd
+import os
+from typing import Union, IO, Any
+
+
+def load_trade_data(file: Union[str, IO[Any]]):
+    """Load trade data from a file path or file-like object."""
+    # If file is a string path
+    if isinstance(file, str):
+        lower = file.lower()
+        if lower.endswith('.csv'):
+            return pd.read_csv(file)
+        elif lower.endswith('.xlsx') or lower.endswith('.xls'):
+            return pd.read_excel(file)
+        else:
+            raise ValueError("Unsupported file format: " + file)
+    # If file has a name attribute (e.g., Streamlit UploadedFile)
+    elif hasattr(file, 'name'):
+        filename = file.name
+        ext = os.path.splitext(filename)[1].lower()
+        if ext == '.csv':
+            return pd.read_csv(file)
+        elif ext in ['.xlsx', '.xls']:
+            return pd.read_excel(file)
+        else:
+            raise ValueError("Unsupported uploaded file format: " + filename)
+    else:
+        raise ValueError("Invalid file type for loading trades.")


### PR DESCRIPTION
## Summary
- implement `load_trade_data` utility to support file paths and Streamlit uploads
- use the new loader in the `FuturesImporter`
- simplify data handling in `app.py` to select sample or uploaded files
- export `load_trade_data` from `data_import`

## Testing
- `pip install pandas numpy openpyxl`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844b688eff48330a0bd10dfe09625c7