### PR TITLE
Handle malformed datetimes

### DIFF
--- a/app.py
+++ b/app.py
@@ -48,9 +48,17 @@ if selected_file:
             st.error(str(e))
             st.stop()
 
-    # Parse datetimes
-    df['entry_time'] = pd.to_datetime(df['entry_time'])
-    df['exit_time'] = pd.to_datetime(df['exit_time'])
+    # Parse datetimes with coercion and ISO8601 format
+    df['entry_time'] = pd.to_datetime(
+        df['entry_time'], errors='coerce', format='ISO8601'
+    )
+    df['exit_time'] = pd.to_datetime(
+        df['exit_time'], errors='coerce', format='ISO8601'
+    )
+
+    if df['entry_time'].isna().any() or df['exit_time'].isna().any():
+        st.warning("Some rows had invalid dates and were dropped.")
+        df = df.dropna(subset=['entry_time', 'exit_time'])
 
     stats = compute_basic_stats(df)
 

--- a/tests/test_date_parsing.py
+++ b/tests/test_date_parsing.py
@@ -1,0 +1,28 @@
+import pandas as pd
+from analytics import compute_basic_stats
+from risk_tool import assess_risk
+
+
+def test_malformed_dates_do_not_crash():
+    df = pd.DataFrame({
+        'symbol': ['ES', 'NQ'],
+        'entry_time': ['2024-01-01T00:00:00', 'bad-date'],
+        'exit_time': ['2024-01-01T01:00:00', 'another-bad'],
+        'entry_price': [1, 1],
+        'exit_price': [2, 2],
+        'qty': [1, 1],
+        'direction': ['long', 'long'],
+        'pnl': [10, -5],
+        'trade_type': ['futures', 'futures'],
+        'broker': ['Demo', 'Demo'],
+    })
+
+    df['entry_time'] = pd.to_datetime(df['entry_time'], errors='coerce', format='ISO8601')
+    df['exit_time'] = pd.to_datetime(df['exit_time'], errors='coerce', format='ISO8601')
+    df = df.dropna(subset=['entry_time', 'exit_time'])
+
+    stats = compute_basic_stats(df)
+    risk = assess_risk(df, account_size=1000, risk_per_trade=0.01, max_daily_loss=100)
+
+    assert 'win_rate' in stats
+    assert 'recommended_position_size' in risk


### PR DESCRIPTION
## Summary
- parse datetimes in `app.py` with `pd.to_datetime(..., errors='coerce', format='ISO8601')`
- drop rows with invalid dates and warn the user
- regression test for malformed dates

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844bb985b6083309b6a0e429b0d8e94