### PR TITLE
Improve PnL parsing

### DIFF
--- a/analytics.py
+++ b/analytics.py
@@ -4,27 +4,33 @@ import numpy as np
 
 def compute_basic_stats(df: pd.DataFrame) -> dict:
     """Calculate core trading performance statistics."""
-    wins = df[df['pnl'] > 0]
-    losses = df[df['pnl'] <= 0]
+    # Ensure PnL is numeric to avoid comparison errors
+    df = df.copy()
+    df["pnl"] = pd.to_numeric(df["pnl"], errors="coerce")
+    df = df.dropna(subset=["pnl"])
+    wins = df[df["pnl"] > 0]
+    losses = df[df["pnl"] <= 0]
     win_rate = len(wins) / len(df) * 100 if len(df) else 0
-    avg_win = wins['pnl'].mean() if not wins.empty else 0
-    avg_loss = losses['pnl'].mean() if not losses.empty else 0
+    avg_win = wins["pnl"].mean() if not wins.empty else 0
+    avg_loss = losses["pnl"].mean() if not losses.empty else 0
     reward_risk = abs(avg_win / avg_loss) if avg_loss != 0 else np.inf
-    expectancy = (win_rate/100) * avg_win + (1 - win_rate/100) * avg_loss
-    profit_factor = wins['pnl'].sum() / abs(losses['pnl'].sum()) if not losses.empty else np.inf
-    equity_curve = df['pnl'].cumsum()
+    expectancy = (win_rate / 100) * avg_win + (1 - win_rate / 100) * avg_loss
+    profit_factor = (
+        wins["pnl"].sum() / abs(losses["pnl"].sum()) if not losses.empty else np.inf
+    )
+    equity_curve = df["pnl"].cumsum()
     max_drawdown = (equity_curve.cummax() - equity_curve).max()
     returns = equity_curve.pct_change().dropna()
     sharpe = np.sqrt(252) * returns.mean() / returns.std() if not returns.empty else 0
 
     return {
-        'win_rate': win_rate,
-        'average_win': avg_win,
-        'average_loss': avg_loss,
-        'reward_risk': reward_risk,
-        'expectancy': expectancy,
-        'max_drawdown': max_drawdown,
-        'profit_factor': profit_factor,
-        'sharpe_ratio': sharpe,
-        'equity_curve': equity_curve,
+        "win_rate": win_rate,
+        "average_win": avg_win,
+        "average_loss": avg_loss,
+        "reward_risk": reward_risk,
+        "expectancy": expectancy,
+        "max_drawdown": max_drawdown,
+        "profit_factor": profit_factor,
+        "sharpe_ratio": sharpe,
+        "equity_curve": equity_curve,
     }

--- a/risk_tool.py
+++ b/risk_tool.py
@@ -1,20 +1,24 @@
 import pandas as pd
 
 
-def assess_risk(df: pd.DataFrame, account_size: float, risk_per_trade: float,
-                 max_daily_loss: float) -> dict:
+def assess_risk(
+    df: pd.DataFrame, account_size: float, risk_per_trade: float, max_daily_loss: float
+) -> dict:
     """Simple risk assessment based on historical PnL."""
+    df = df.copy()
+    df["pnl"] = pd.to_numeric(df["pnl"], errors="coerce")
+    df = df.dropna(subset=["pnl"])
     stats = {}
-    avg_loss = df[df['pnl'] < 0]['pnl'].mean() if not df.empty else 0
+    avg_loss = df[df["pnl"] < 0]["pnl"].mean() if not df.empty else 0
     recommended_size = account_size * risk_per_trade / abs(avg_loss) if avg_loss else 0
     if recommended_size > account_size:
         recommended_size = account_size
 
-    stats['recommended_position_size'] = recommended_size
-    stats['max_daily_loss'] = max_daily_loss
-    daily_pnl = df.groupby(df['exit_time'].dt.date)['pnl'].sum()
+    stats["recommended_position_size"] = recommended_size
+    stats["max_daily_loss"] = max_daily_loss
+    daily_pnl = df.groupby(df["exit_time"].dt.date)["pnl"].sum()
     if any(daily_pnl < -max_daily_loss):
-        stats['warning'] = 'Historical trades exceed your max daily loss.'
+        stats["warning"] = "Historical trades exceed your max daily loss."
     else:
-        stats['warning'] = ''
+        stats["warning"] = ""
     return stats


### PR DESCRIPTION
## Summary
- cast `pnl` to numeric in `compute_basic_stats` and `assess_risk`
- drop rows where `pnl` cannot be parsed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844e4a9979083309b1a8de84e2551b3