### PR TITLE
Add advanced analytics metrics

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,7 +6,15 @@ from fpdf import FPDF
 from data_import.futures_importer import FuturesImporter
 from data_import.base_importer import REQUIRED_COLUMNS
 from data_import.utils import load_trade_data
-from analytics import compute_basic_stats, performance_over_time
+from analytics import (
+    compute_basic_stats,
+    performance_over_time,
+    median_results,
+    profit_factor_by_symbol,
+    trade_duration_stats,
+    max_streaks,
+    rolling_metrics,
+)
 from risk_tool import assess_risk
 from payment import PaymentGateway
 
@@ -134,6 +142,27 @@ if selected_file:
     perf = performance_over_time(filtered_df, freq='M')
     st.subheader('Performance Over Time')
     st.bar_chart(perf.set_index('period')['pnl'])
+
+    med = median_results(filtered_df)
+    st.subheader('Median Results')
+    st.write(med)
+
+    pf_sym = profit_factor_by_symbol(filtered_df)
+    st.subheader('Profit Factor by Symbol')
+    st.dataframe(pf_sym, use_container_width=True)
+
+    duration = trade_duration_stats(filtered_df)
+    st.subheader('Trade Duration Stats (minutes)')
+    st.write(duration)
+
+    streak = max_streaks(filtered_df)
+    st.subheader('Max Streaks')
+    st.write(streak)
+
+    rolling = rolling_metrics(filtered_df, window=10)
+    if not rolling.empty:
+        st.subheader('Rolling Metrics (10 trades)')
+        st.line_chart(rolling.set_index('end_index')[['win_rate', 'profit_factor']])
 
     st.subheader('Trades')
     st.dataframe(filtered_df, use_container_width=True)

--- a/tests/test_max_streaks.py
+++ b/tests/test_max_streaks.py
@@ -1,0 +1,22 @@
+import pandas as pd
+from analytics import max_streaks
+
+
+def test_max_streaks_basic():
+    pnl_values = [100, 200, -50, -50, -100, 150, 150, 150, -30]
+    df = pd.DataFrame({
+        "symbol": ["ES"] * len(pnl_values),
+        "entry_time": ["2024-01-01"] * len(pnl_values),
+        "exit_time": ["2024-01-01"] * len(pnl_values),
+        "entry_price": [1] * len(pnl_values),
+        "exit_price": [1] * len(pnl_values),
+        "qty": [1] * len(pnl_values),
+        "direction": ["long"] * len(pnl_values),
+        "pnl": pnl_values,
+        "trade_type": ["d"] * len(pnl_values),
+        "broker": ["Demo"] * len(pnl_values),
+    })
+
+    streaks = max_streaks(df)
+    assert streaks["max_win_streak"] == 3
+    assert streaks["max_loss_streak"] == 3

--- a/tests/test_median_results.py
+++ b/tests/test_median_results.py
@@ -1,0 +1,29 @@
+import pandas as pd
+from analytics import median_results
+
+
+def test_median_results_basic():
+    data = [
+        ["ES", "2023-01-01", "2023-01-01", 1, 1, 1, "long", 100, "daytrade", "Demo"],
+        ["ES", "2023-01-02", "2023-01-02", 1, 1, 1, "long", -50, "daytrade", "Demo"],
+        ["ES", "2023-01-03", "2023-01-03", 1, 1, 1, "long", 200, "daytrade", "Demo"],
+        ["ES", "2023-01-04", "2023-01-04", 1, 1, 1, "long", -100, "daytrade", "Demo"],
+    ]
+    cols = [
+        "symbol",
+        "entry_time",
+        "exit_time",
+        "entry_price",
+        "exit_price",
+        "qty",
+        "direction",
+        "pnl",
+        "trade_type",
+        "broker",
+    ]
+    df = pd.DataFrame(data, columns=cols)
+
+    res = median_results(df)
+    assert res["median_pnl"] == 25
+    assert res["median_win"] == 150
+    assert res["median_loss"] == -75

--- a/tests/test_profit_factor_by_symbol.py
+++ b/tests/test_profit_factor_by_symbol.py
@@ -1,0 +1,30 @@
+import pandas as pd
+from analytics import profit_factor_by_symbol
+
+
+def test_profit_factor_by_symbol_basic():
+    data = [
+        ["ES", "2024-01-01", "2024-01-01", 1, 1, 1, "long", 100, "d", "Demo"],
+        ["ES", "2024-01-02", "2024-01-02", 1, 1, 1, "long", -50, "d", "Demo"],
+        ["NQ", "2024-01-01", "2024-01-01", 1, 1, 1, "long", 30, "d", "Demo"],
+        ["NQ", "2024-01-02", "2024-01-02", 1, 1, 1, "long", -30, "d", "Demo"],
+    ]
+    cols = [
+        "symbol",
+        "entry_time",
+        "exit_time",
+        "entry_price",
+        "exit_price",
+        "qty",
+        "direction",
+        "pnl",
+        "trade_type",
+        "broker",
+    ]
+    df = pd.DataFrame(data, columns=cols)
+
+    pf = profit_factor_by_symbol(df)
+    es_pf = pf.loc[pf["symbol"] == "ES", "profit_factor"].iloc[0]
+    nq_pf = pf.loc[pf["symbol"] == "NQ", "profit_factor"].iloc[0]
+    assert es_pf == 2
+    assert nq_pf == 1

--- a/tests/test_rolling_metrics.py
+++ b/tests/test_rolling_metrics.py
@@ -1,0 +1,23 @@
+import pandas as pd
+from analytics import rolling_metrics
+
+
+def test_rolling_metrics_basic():
+    pnl = [10, -5, 20, -10, 5]
+    df = pd.DataFrame({
+        "symbol": ["ES"] * len(pnl),
+        "entry_time": ["2024-01-01"] * len(pnl),
+        "exit_time": ["2024-01-01"] * len(pnl),
+        "entry_price": [1] * len(pnl),
+        "exit_price": [1] * len(pnl),
+        "qty": [1] * len(pnl),
+        "direction": ["long"] * len(pnl),
+        "pnl": pnl,
+        "trade_type": ["d"] * len(pnl),
+        "broker": ["Demo"] * len(pnl),
+    })
+
+    roll = rolling_metrics(df, window=3)
+    assert len(roll) == 3
+    assert roll.loc[0, "win_rate"] == 66.66666666666666
+    assert roll.loc[0, "profit_factor"] == 6

--- a/tests/test_trade_duration_stats.py
+++ b/tests/test_trade_duration_stats.py
@@ -1,0 +1,28 @@
+import pandas as pd
+from analytics import trade_duration_stats
+
+
+def test_trade_duration_stats_basic():
+    data = [
+        ["ES", "2024-01-01T00:00:00", "2024-01-01T00:30:00", 1, 1, 1, "long", 10, "d", "Demo"],
+        ["ES", "2024-01-01T01:00:00", "2024-01-01T02:00:00", 1, 1, 1, "long", -5, "d", "Demo"],
+    ]
+    cols = [
+        "symbol",
+        "entry_time",
+        "exit_time",
+        "entry_price",
+        "exit_price",
+        "qty",
+        "direction",
+        "pnl",
+        "trade_type",
+        "broker",
+    ]
+    df = pd.DataFrame(data, columns=cols)
+
+    stats = trade_duration_stats(df)
+    assert stats["average_minutes"] == 45
+    assert stats["max_minutes"] == 60
+    assert stats["min_minutes"] == 30
+    assert stats["median_minutes"] == 45


### PR DESCRIPTION
## Summary
- extend `analytics` with five new utility functions
- show the new metrics inside the Streamlit UI
- test the analytics helpers

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68456e2b96888330b94fce0442da7bd1