### PR TITLE
Add visualization helpers and dashboard charts

### DIFF
--- a/analytics.py
+++ b/analytics.py
@@ -52,3 +52,22 @@ def performance_over_time(df: pd.DataFrame, freq: str = "M") -> pd.DataFrame:
 
     result = pd.DataFrame({"period": pnl.index, "pnl": pnl.values, "win_rate": win_rate.values})
     return result
+
+
+def histogram_data(df: pd.DataFrame, column: str, bins: int = 20) -> pd.DataFrame:
+    """Return histogram counts for a numeric column."""
+    if column not in df.columns or df.empty:
+        return pd.DataFrame({"bin": [], "count": []})
+
+    data = pd.to_numeric(df[column], errors="coerce").dropna()
+    counts, edges = np.histogram(data, bins=bins)
+    midpoints = (edges[:-1] + edges[1:]) / 2
+    return pd.DataFrame({"bin": midpoints, "count": counts})
+
+
+def heatmap_data(df: pd.DataFrame, x_col: str, y_col: str) -> pd.DataFrame:
+    """Return a pivot table counting occurrences for heatmap display."""
+    if df.empty or x_col not in df.columns or y_col not in df.columns:
+        return pd.DataFrame()
+
+    return pd.crosstab(df[y_col], df[x_col])

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -1,7 +1,7 @@
 import pytest
 import pandas as pd
 import numpy as np
-from analytics import compute_basic_stats
+from analytics import compute_basic_stats, histogram_data, heatmap_data
 
 
 def test_compute_basic_stats_known_data():
@@ -25,4 +25,20 @@ def test_compute_basic_stats_known_data():
     assert stats['max_drawdown'] == 100
     # approximate due to floating point operations
     assert stats['sharpe_ratio'] == pytest.approx(6.3835034744, rel=1e-6)
+
+
+def test_histogram_and_heatmap_shapes():
+    df = pd.DataFrame({
+        'symbol': ['ES', 'ES', 'NQ', 'NQ'],
+        'direction': ['long', 'short', 'long', 'short'],
+        'pnl': [10, -5, 20, -8],
+    })
+
+    hist = histogram_data(df, 'pnl', bins=2)
+    assert hist.shape[1] == 2  # bin and count columns
+    assert len(hist) == 2
+
+    heat = heatmap_data(df, 'symbol', 'direction')
+    # 2 directions x 2 symbols
+    assert heat.shape == (2, 2)
 


### PR DESCRIPTION
## Summary
- add `histogram_data` and `heatmap_data` to `analytics.py`
- display Plotly histogram and heatmap using new helper functions
- refactor main dashboard into tabs
- test histogram and heatmap helper outputs

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68456e2db4e083308d0ebb5d1ba627f8