### PR TITLE
Add AI insights and journal tab

### DIFF
--- a/ai_insights.py
+++ b/ai_insights.py
@@ -1,0 +1,37 @@
+import pandas as pd
+import numpy as np
+
+
+def detect_outliers_zscore(df: pd.DataFrame, column: str = "pnl", threshold: float = 3.0) -> pd.DataFrame:
+    """Flag outlier trades based on z-score.
+
+    Returns a copy of ``df`` with additional ``zscore`` and ``outlier`` columns.
+    Trades where ``|zscore| > threshold`` are marked as outliers.
+    """
+    if df.empty:
+        result = df.copy()
+        result["zscore"] = []
+        result["outlier"] = []
+        return result
+
+    numeric = pd.to_numeric(df[column], errors="coerce")
+    z = (numeric - numeric.mean()) / numeric.std(ddof=0)
+
+    result = df.copy()
+    result["zscore"] = z
+    result["outlier"] = z.abs() > threshold
+    return result
+
+
+def _call_llm_api(prompt: str) -> str:
+    """Placeholder for a call to an LLM API."""
+    # TODO: integrate with OpenAI or another provider
+    return f"LLM response for: {prompt[:50]}..."
+
+
+def summarize_trades(df: pd.DataFrame) -> str:
+    """Generate a simple summary for the given trades using a placeholder LLM."""
+    if df.empty:
+        return ""
+    prompt = f"Summarize the following trades: {df.to_dict(orient='records')}"
+    return _call_llm_api(prompt)

--- a/tests/test_ai_insights.py
+++ b/tests/test_ai_insights.py
@@ -1,0 +1,22 @@
+import pandas as pd
+from ai_insights import detect_outliers_zscore
+
+
+def test_detect_outliers_zscore_flags_extreme_values():
+    df = pd.DataFrame({
+        'pnl': [10, 12, 11, 9, 200],
+        'symbol': ['A', 'A', 'A', 'A', 'A'],
+        'entry_time': pd.to_datetime(['2024-01-01']*5),
+        'exit_time': pd.to_datetime(['2024-01-01']*5),
+        'entry_price': [1]*5,
+        'exit_price': [1]*5,
+        'qty': [1]*5,
+        'direction': ['long']*5,
+        'trade_type': ['f']*5,
+        'broker': ['demo']*5,
+    })
+
+    result = detect_outliers_zscore(df, column='pnl', threshold=1.5)
+    outliers = result[result['outlier']]
+    assert len(outliers) == 1
+    assert outliers.iloc[0]['pnl'] == 200


### PR DESCRIPTION
## Summary
- implement AI Insights module with z-score based outlier detection and placeholder LLM hook
- integrate module into Streamlit app via new Journal tab
- display flagged trades and generated notes in app
- add unit tests for outlier detection

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68456e3414f08330a13f50581ed47c7b