### PR TITLE
Add account-based analytics

### DIFF
--- a/analytics.py
+++ b/analytics.py
@@ -52,3 +52,19 @@ def performance_over_time(df: pd.DataFrame, freq: str = "M") -> pd.DataFrame:
 
     result = pd.DataFrame({"period": pnl.index, "pnl": pnl.values, "win_rate": win_rate.values})
     return result
+
+
+def aggregate_by_account(df: pd.DataFrame) -> pd.DataFrame:
+    """Return total P&L and win rate for each account."""
+    if df.empty or 'account' not in df.columns:
+        return pd.DataFrame(columns=["account", "pnl", "win_rate"])
+
+    df = df.copy()
+    df["pnl"] = pd.to_numeric(df["pnl"], errors="coerce")
+    df = df.dropna(subset=["pnl"])
+
+    grouped = df.groupby("account")
+    pnl = grouped["pnl"].sum()
+    win_rate = grouped.apply(lambda g: (g["pnl"] > 0).mean() * 100)
+
+    return pd.DataFrame({"account": pnl.index, "pnl": pnl.values, "win_rate": win_rate.values})

--- a/app.py
+++ b/app.py
@@ -6,7 +6,7 @@ from fpdf import FPDF
 from data_import.futures_importer import FuturesImporter
 from data_import.base_importer import REQUIRED_COLUMNS
 from data_import.utils import load_trade_data
-from analytics import compute_basic_stats, performance_over_time
+from analytics import compute_basic_stats, performance_over_time, aggregate_by_account
 from risk_tool import assess_risk
 from payment import PaymentGateway
 
@@ -134,6 +134,11 @@ if selected_file:
     perf = performance_over_time(filtered_df, freq='M')
     st.subheader('Performance Over Time')
     st.bar_chart(perf.set_index('period')['pnl'])
+
+    if 'account' in filtered_df.columns and filtered_df['account'].nunique() > 0:
+        acct_perf = aggregate_by_account(filtered_df)
+        st.subheader('Performance by Account')
+        st.bar_chart(acct_perf.set_index('account')['pnl'])
 
     st.subheader('Trades')
     st.dataframe(filtered_df, use_container_width=True)

--- a/data_import/base_importer.py
+++ b/data_import/base_importer.py
@@ -7,7 +7,7 @@ REQUIRED_COLUMNS = [
     'exit_price', 'qty', 'direction', 'pnl', 'trade_type', 'broker'
 ]
 
-OPTIONAL_COLUMNS = ['notes']
+OPTIONAL_COLUMNS = ['notes', 'account']
 
 class BaseImporter(ABC):
     """Abstract base class for trade data importers."""

--- a/models.py
+++ b/models.py
@@ -13,6 +13,7 @@ class Trade:
     pnl: float
     trade_type: str
     broker: str
+    account: str = ""
 
     @property
     def duration(self) -> float:
@@ -38,5 +39,6 @@ class Trade:
             direction=s['direction'],
             pnl=s['pnl'],
             trade_type=s['trade_type'],
-            broker=s['broker']
+            broker=s['broker'],
+            account=s.get('account', '')
         )

--- a/tests/test_account_aggregation.py
+++ b/tests/test_account_aggregation.py
@@ -1,0 +1,25 @@
+import pandas as pd
+from data_import import FuturesImporter
+from analytics import aggregate_by_account
+
+def test_merge_multiple_files_account_stats(tmp_path):
+    csv1 = tmp_path / "t1.csv"
+    csv2 = tmp_path / "t2.csv"
+    cols = ['symbol','entry_time','exit_time','entry_price','exit_price','qty','direction','pnl','trade_type','broker','account']
+    data1 = [
+        ['ES','2024-01-01','2024-01-01',1,2,1,'long',100,'f','D','ACC1'],
+        ['ES','2024-01-01','2024-01-01',1,2,1,'long',-50,'f','D','ACC1']
+    ]
+    data2 = [
+        ['ES','2024-01-02','2024-01-02',1,2,1,'long',20,'f','D','ACC2'],
+        ['ES','2024-01-03','2024-01-03',1,2,1,'long',30,'f','D','ACC1']
+    ]
+    pd.DataFrame(data1, columns=cols).to_csv(csv1, index=False)
+    pd.DataFrame(data2, columns=cols).to_csv(csv2, index=False)
+
+    imp = FuturesImporter()
+    df = pd.concat([imp.load(str(csv1)), imp.load(str(csv2))], ignore_index=True)
+    summary = aggregate_by_account(df)
+    res = summary.set_index('account')['pnl'].to_dict()
+    assert res['ACC1'] == 80
+    assert res['ACC2'] == 20

--- a/tests/test_importer_account.py
+++ b/tests/test_importer_account.py
@@ -1,17 +1,17 @@
 import pandas as pd
 from data_import import FuturesImporter
-from data_import.base_importer import REQUIRED_COLUMNS
+from data_import.base_importer import REQUIRED_COLUMNS, OPTIONAL_COLUMNS
 
-def test_load_with_optional_notes(tmp_path):
+def test_load_with_optional_account(tmp_path):
     csv = tmp_path / "trades.csv"
     data = [
-        ["ES", "2024-01-01", "2024-01-01", 1, 2, 1, "long", 100, "futures", "Demo", "good trade"],
+        ["ES", "2024-01-01", "2024-01-01", 1, 2, 1, "long", 100, "futures", "Demo", "ACC1"]
     ]
-    cols = REQUIRED_COLUMNS + ['notes']
+    cols = REQUIRED_COLUMNS + ["account"]
     pd.DataFrame(data, columns=cols).to_csv(csv, index=False)
 
     importer = FuturesImporter()
     df = importer.load(str(csv))
     for col in REQUIRED_COLUMNS:
         assert col in df.columns
-    assert "notes" in df.columns
+    assert "account" in df.columns


### PR DESCRIPTION
## Summary
- support `account` on Trade objects
- include `account` as optional column in CSV importer
- add account aggregation utility
- visualize account performance in the dashboard
- test importer with optional account field
- test merging data from multiple CSV files and verifying analytics per account
- adjust optional notes test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68456e33a9588330a513e88cfa00c0f8