### PR TITLE
Fix risk assessment for NaN avg_loss

### DIFF
--- a/risk_tool.py
+++ b/risk_tool.py
@@ -10,7 +10,10 @@ def assess_risk(
     df = df.dropna(subset=["pnl"])
     stats = {}
     avg_loss = df[df["pnl"] < 0]["pnl"].mean() if not df.empty else 0
-    recommended_size = account_size * risk_per_trade / abs(avg_loss) if avg_loss else 0
+    if pd.isna(avg_loss) or avg_loss == 0:
+        recommended_size = 0
+    else:
+        recommended_size = account_size * risk_per_trade / abs(avg_loss)
     if recommended_size > account_size:
         recommended_size = account_size
 

--- a/tests/test_risk_tool.py
+++ b/tests/test_risk_tool.py
@@ -65,3 +65,24 @@ def test_empty_dataframe():
 
     assert stats['recommended_position_size'] == 0
     assert stats['warning'] == ''
+
+
+def test_all_winning_trades():
+    data = [
+        ['ES', '2024-01-01', '2024-01-01', 100, 110, 1, 'long', 10, 'daytrade', 'Demo'],
+        ['ES', '2024-01-02', '2024-01-02', 100, 115, 1, 'long', 15, 'daytrade', 'Demo'],
+    ]
+    cols = ['symbol', 'entry_time', 'exit_time', 'entry_price', 'exit_price', 'qty', 'direction', 'pnl', 'trade_type', 'broker']
+    df = pd.DataFrame(data, columns=cols)
+    df['entry_time'] = pd.to_datetime(df['entry_time'])
+    df['exit_time'] = pd.to_datetime(df['exit_time'])
+
+    stats = assess_risk(
+        df,
+        account_size=10000,
+        risk_per_trade=0.02,
+        max_daily_loss=500,
+    )
+
+    assert stats['recommended_position_size'] == 0
+    assert stats['warning'] == ''


### PR DESCRIPTION
## Summary
- avoid dividing by NaN when calculating recommended position size
- test that all-winning trades yield a position size of zero

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684572048a7883309f054d0a6c47f897