### PR TITLE
Fix sharpe ratio calc with constant returns

### DIFF
--- a/analytics.py
+++ b/analytics.py
@@ -21,7 +21,14 @@ def compute_basic_stats(df: pd.DataFrame) -> dict:
     equity_curve = df["pnl"].cumsum()
     max_drawdown = (equity_curve.cummax() - equity_curve).max()
     returns = equity_curve.pct_change().dropna()
-    sharpe = np.sqrt(252) * returns.mean() / returns.std() if not returns.empty else 0
+    if returns.empty:
+        sharpe = 0
+    else:
+        std = returns.std()
+        if std == 0 or np.isnan(std):
+            sharpe = 0
+        else:
+            sharpe = np.sqrt(252) * returns.mean() / std
 
     return {
         "win_rate": win_rate,

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -26,3 +26,13 @@ def test_compute_basic_stats_known_data():
     # approximate due to floating point operations
     assert stats['sharpe_ratio'] == pytest.approx(6.3835034744, rel=1e-6)
 
+
+def test_sharpe_ratio_single_trade_is_zero():
+    df = pd.DataFrame([
+        ['ES', '2024-01-01', '2024-01-01', 1, 1, 1, 'long', 10, 'daytrade', 'Demo']
+    ], columns=['symbol','entry_time','exit_time','entry_price','exit_price','qty','direction','pnl','trade_type','broker'])
+
+    stats = compute_basic_stats(df)
+
+    assert stats['sharpe_ratio'] == 0
+


### PR DESCRIPTION
## Summary
- handle edge cases in compute_basic_stats Sharpe ratio calculation
- add regression test for single-trade Sharpe ratio

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845f8d479388330956955406c764880