### PR TITLE
Emphasize requirements installation before tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ source .venv/bin/activate
 pip install -r requirements.txt
 ```
 
-Then run the test suite:
+Run `pip install -r requirements.txt` before executing `pytest` to ensure all
+dependencies are available. Then run the test suite:
 
 ```bash
 pytest


### PR DESCRIPTION
## Summary
- update README to call out installing requirements before running tests

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845fb8a3b4483309d64124f8d8ba9f3