### PR TITLE
Add histogram/heatmap utilities and edge case tests

### DIFF
--- a/analytics.py
+++ b/analytics.py
@@ -149,3 +149,40 @@ def rolling_metrics(df: pd.DataFrame, window: int = 30) -> pd.DataFrame:
             }
         )
     return pd.DataFrame(results)
+
+
+def histogram_data(df: pd.DataFrame, column: str, bins: int = 10) -> pd.DataFrame:
+    """Return histogram counts for a numeric column."""
+    if df.empty or column not in df.columns:
+        return pd.DataFrame(columns=["bin", "count"])
+
+    values = pd.to_numeric(df[column], errors="coerce").dropna()
+    if values.empty:
+        return pd.DataFrame(columns=["bin", "count"])
+
+    counts, edges = np.histogram(values, bins=bins)
+    labels = [f"{edges[i]}-{edges[i+1]}" for i in range(len(edges) - 1)]
+    return pd.DataFrame({"bin": labels, "count": counts})
+
+
+def heatmap_data(
+    df: pd.DataFrame,
+    x_col: str,
+    y_col: str,
+    value_col: str = "pnl",
+    aggfunc: str = "sum",
+) -> pd.DataFrame:
+    """Pivot dataframe for heatmap plotting."""
+    required = {x_col, y_col, value_col}
+    if df.empty or not required.issubset(df.columns):
+        return pd.DataFrame()
+
+    pivot = pd.pivot_table(
+        df,
+        values=value_col,
+        index=y_col,
+        columns=x_col,
+        aggfunc=aggfunc,
+        fill_value=0,
+    )
+    return pivot

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -1,7 +1,7 @@
 import pytest
 import pandas as pd
 import numpy as np
-from analytics import compute_basic_stats
+from analytics import compute_basic_stats, histogram_data, heatmap_data
 
 
 def test_compute_basic_stats_known_data():
@@ -25,4 +25,16 @@ def test_compute_basic_stats_known_data():
     assert stats['max_drawdown'] == 100
     # approximate due to floating point operations
     assert stats['sharpe_ratio'] == pytest.approx(6.3835034744, rel=1e-6)
+
+
+def test_histogram_missing_column_returns_empty():
+    df = pd.DataFrame({'pnl': [1, 2, 3]})
+    hist = histogram_data(df, 'nonexistent')
+    assert hist.empty
+
+
+def test_heatmap_empty_dataframe_returns_empty():
+    df = pd.DataFrame(columns=['x', 'y', 'val'])
+    heat = heatmap_data(df, 'x', 'y', 'val')
+    assert heat.empty
 


### PR DESCRIPTION
## Summary
- implement `histogram_data` and `heatmap_data` helpers
- add tests for missing column and empty dataframe cases

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845f8d92098833086af214c848951f7