### PR TITLE
Improve runtime robustness

### DIFF
--- a/interactive_table.py
+++ b/interactive_table.py
@@ -3,9 +3,17 @@ from st_aggrid import GridOptionsBuilder
 
 
 def compute_trade_result(df: pd.DataFrame) -> pd.DataFrame:
-    """Add trade_result column indicating win or loss."""
+    """Add trade_result column indicating win or loss.
+
+    PnL values may come in as strings from uploaded CSV files. We coerce to
+    numeric so comparisons don't raise type errors. Invalid values become ``NaN``
+    and are treated as losses to avoid misleading results.
+    """
     df = df.copy()
-    df["trade_result"] = df["pnl"].apply(lambda x: "Win" if x >= 0 else "Loss")
+    df["pnl"] = pd.to_numeric(df["pnl"], errors="coerce")
+    df["trade_result"] = df["pnl"].apply(
+        lambda x: "Win" if pd.notna(x) and x >= 0 else "Loss"
+    )
     return df
 
 

--- a/risk_tool.py
+++ b/risk_tool.py
@@ -7,7 +7,8 @@ def assess_risk(
     """Simple risk assessment based on historical PnL."""
     df = df.copy()
     df["pnl"] = pd.to_numeric(df["pnl"], errors="coerce")
-    df = df.dropna(subset=["pnl"])
+    df["exit_time"] = pd.to_datetime(df["exit_time"], errors="coerce")
+    df = df.dropna(subset=["pnl", "exit_time"])
     stats = {}
     avg_loss = df[df["pnl"] < 0]["pnl"].mean() if not df.empty else 0
     if pd.isna(avg_loss) or avg_loss == 0:


### PR DESCRIPTION
## Summary
- convert PnL to numeric in `compute_trade_result`
- drop invalid dates inside `assess_risk`

## Testing
- `pytest -q`
- `streamlit run app.py --server.headless true --server.port 8501`

------
https://chatgpt.com/codex/tasks/task_e_684619edfebc8330bad912bd9ffb50f5