### PR TITLE
Update pandas and add Python version recommendation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ pip install -r requirements.txt  # install pinned versions
 ```
 Dependencies are pinned in `requirements.txt` to ensure reproducible installations.
 Interactive tables are powered by `streamlit-aggrid` pinned at version 1.1.5.
+Python 3.11 or 3.12 is recommended. Installing with Python 3.13 may fail because pre-built wheels for some packages (e.g. pandas) are not yet available.
 ## Testing
 
 First create a virtual environment and install the required packages:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Core data analysis
-pandas==2.1.4
+pandas==2.2.2
 numpy==1.26.4
 
 # Visualization and app framework


### PR DESCRIPTION
## Summary
- update pandas to 2.2.2
- document that Python 3.13 may fail and recommend Python 3.11/3.12

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pip install -r requirements.txt` *(fails during pandas build on Python 3.13)*

------
https://chatgpt.com/codex/tasks/task_e_68461e0cd2948330b30da8d2b58d4a70